### PR TITLE
Change regular expression to include newline

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -69,7 +69,7 @@ class filter_collapsible extends moodle_text_filter {
                 $replaced .= $this->end_region($tail);
             } else {
                 $started = true;
-                if (preg_match('/^\[([^\]]+)\](.*)/', $tail, $match)) {
+                if (preg_match('/^\[([^\]]+)\]([\s\S]*)/', $tail, $match)) {
                     $more = $match[1];
                     $tail = $match[2];
                 } else {


### PR DESCRIPTION
This came up in testing. This patch fixes this issue:

Problem: When you break to a new line what is written after break does not appear. Below example will not display past the text "What about message 2?"
{collapsible}[Pika] What about message 2? 

The pika is a small-sized mammal that is found across the Northern Hemisphere. Despite their rodent-like appearance, pikas are actually closely related to rabbits and hares. Pikas are most commonly identified by their small, rounded body and lack of tail. Pikas prefer the colder climates and are generally found in mountainous regions and rocky areas where there tend to be fewer predators. There are more than 30 different species of pika that range in colour and size, across Asia, North America and parts of Europe. Pikas are solitary animals and are found inhabiting piles of rocks close to meadows where there is little in the way. Pikas defend their territory by whistling to one another, and their large, rounded ears come in useful to hear the calls from competing pikas. Pikas are herbivorous animals and the pika therefore has a diet based on vegetation. The pika is a diurnal animal and forages for grasses, seeds, weeds, thistles and berries during the hours of daylight. Although the pika inhabits regions where there are few other animals, the pika has a number of predators mainly due to it's small size. The weasel is the main predator of the pika, along with birds of prey, dogs, foxes and cats. During the mating season male and female pikas on opposite territories call to each other and form a pair bond. The female pika is able to produce two litters per year, but usually only one leads to successful young. The female pika gives birth to between 1 and 5 babies, after a gestation period of about a month. When the babies are old enough to be independent, they often settle near to their parents.
{collapsible}
